### PR TITLE
Adding --rerun-incomplete to dry run command

### DIFF
--- a/rna-seek
+++ b/rna-seek
@@ -578,6 +578,7 @@ def dryrun(outdir, config='config.json', snakefile=os.path.join('workflow', 'Sna
             'snakemake', '-npr',
             '-s', str(snakefile),
             '--use-singularity',
+            '--rerun-incomplete',
             '--cores', '4',
             '--configfile={}'.format(config)
         ], cwd = outdir,


### PR DESCRIPTION
This fixes the `IncompleteFilesException` error that occurs when trying to re-start a run was killed prematurely.